### PR TITLE
Add the ability to send cookies

### DIFF
--- a/layout-shift-gif.js
+++ b/layout-shift-gif.js
@@ -192,4 +192,4 @@ async function createGif (url, device) {
   }
 }
 
-createGif(options.url, options.device, options.cookies, options.filename).then(e => console.log(e)).catch(e => console.log(e))
+createGif(options.url, options.device, options.filename).then(e => console.log(e)).catch(e => console.log(e))

--- a/layout-shift-gif.js
+++ b/layout-shift-gif.js
@@ -4,11 +4,12 @@
 const yargs = require('yargs')
 
 const options = yargs
-  .usage('Usage: --url <url> --device [mobile|desktop] --output <filename>')
+  .usage('Usage: --url <url> --device [mobile|desktop] --cookies <filename> --output <filename>')
   .example('layout-shift-gif --url https://blacklivesmatter.com/ --device mobile --output layoutshift.gif')
-  .default({ device: 'mobile', output: 'layoutshift.gif' })
+  .default({ device: 'mobile', cookies: null, output: 'layoutshift.gif' })
   .describe('url', 'Website url')
   .describe('device', 'Device type [mobile|desktop]')
+  .describe('cookies', 'A JSON file with the cookies to send with the request')
   .describe('output', 'Output filename')
   .demandOption(['url'])
   .argv
@@ -74,6 +75,10 @@ async function createGif (url, device) {
 
   try {
     const page = await browser.newPage()
+    if (options.cookies) {
+      const cookies = JSON.parse(fs.readFileSync(options.cookies))
+      await page.setCookie(...cookies)
+    }
     const client = await page.target().createCDPSession()
     await client.send('Network.enable')
     await client.send('ServiceWorker.enable')
@@ -187,4 +192,4 @@ async function createGif (url, device) {
   }
 }
 
-createGif(options.url, options.device, options.filename).then(e => console.log(e)).catch(e => console.log(e))
+createGif(options.url, options.device, options.cookies, options.filename).then(e => console.log(e)).catch(e => console.log(e))

--- a/layout-shift-gif.js
+++ b/layout-shift-gif.js
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* Args */
 const yargs = require('yargs')
 


### PR DESCRIPTION
A cookie popup often hides the elements causing the CLS. This allows you to use a JSON file in the format puppeteer page.setCookies requires to send cookies along with the request so that the cookie popup isn't shown.

I also need to add a license to the file to meet Google's requirement for submitting the patch. 